### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-#License - ISC
+# License - ISC
 
 Copyright (c) 2015, Dow Jones & Company, Inc.
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ fiveby(function (browser) {
     });
 });
 ```
-####Run it (quick)
+#### Run it (quick)
 ```
 mocha tests/** --delay --timeout 30000
 ```
-####OR (recommended)
+#### OR (recommended)
 Add [gulp](http://gulpjs.com/) and some convention to make it even more powerful: [slush-fiveby](https://github.com/dowjones/slush-fiveby). slush-fiveby is a simple fiveby project generator/example.
 
-###What's unique about fiveby?
+### What's unique about fiveby?
 
 - Cleanly allows mocha and webdriverjs to coexist
 - MUCH simpler configuration and less boilerplate code
@@ -36,7 +36,7 @@ Add [gulp](http://gulpjs.com/) and some convention to make it even more powerful
 - [Sends test traffic to a HAR file](/docs/har-dump.md)
 - [more](/docs/comparisons.md)
 
-###Configuration - fiveby-config.json
+### Configuration - fiveby-config.json
 
 ```json
 {
@@ -60,15 +60,15 @@ disableBrowsers and hubUrl are optional, disableBrowsers defaults to false
 
 *Use phantomjs 2.0: http://phantomjs.org/download.html
 
-###English?
+### English?
 
-#####Have little to no experience with end to end testing?
+##### Have little to no experience with end to end testing?
 
 Ok, this tool will allow you to write a bit of javascript that will open any browser (or mobile app), emulate user behavior via a few simple commands, and then verify what's displayed onscreen is correct. You can compile large suites of these tests and easily run them against many different browsers at once and get nice reports. It can be run with something like [jenkins](http://jenkins-ci.org/) to automate further. Or use any of the popular SaaS providers like:
 
 [![Sauce Labs](https://saucelabs.com/images/sauce-labs-logo.png)](http://saucelabs.com) [![BrowserStack](https://d2ogrdw2mh0rsl.cloudfront.net/production/images/mail/browserstack-logo-footer.png)](http://browserstack.com) <a href="http://testingbot.com/"><img src="https://testingbot.com/assets/logo.png" height="60" width="120" ></a>
 
-###Pre-reqs
+### Pre-reqs
 
 - [node.js](http://nodejs.org/)
 - [mocha cli](http://mochajs.org/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-####1. Introduction
+#### 1. Introduction
 
   Automated browser testing is writing code to simulate a user: click element x, wait for event y, click again, assert results, repeat.
 
-####2. Project Structure - the important part to note here is the distinction between tests and components. Components abstract the dom details from the tests using the [page objects pattern](pop.md). Services are where you perform actions that have nothing to do with the browser, like rest calls used by setup/teardown.
+#### 2. Project Structure - the important part to note here is the distinction between tests and components. Components abstract the dom details from the tests using the [page objects pattern](pop.md). Services are where you perform actions that have nothing to do with the browser, like rest calls used by setup/teardown.
 
 ```
   └── tests
@@ -42,15 +42,15 @@
           └── ...
 ```  
 
-####4. Bad Practices
+#### 4. Bad Practices
   - Don't use callbacks. Selenium is promise based and Mocha is promise friendly. Mixing them is ugly and hard to understand. If you don't know how to do something cleanly with promises discuss with someone who does.
   - Don't execute javascript in the browser, your tests should rely 100% on DOM interaction. Remember you are emulating a user! Direct javascript makes for brittle and ugly tests.
 
-####5. [Code Style & API](api.md)
+#### 5. [Code Style & API](api.md)
 
-####6.[External Dependencies](external-dependencies.md)
+#### 6.[External Dependencies](external-dependencies.md)
 
-####7. Based on:
+#### 7. Based on:
 
 *Selenium Javascript* api:
 
@@ -66,4 +66,4 @@
 
 > https://github.com/shouldjs/should.js
 
-####8. [FAQ](/docs/faq.md)
+#### 8. [FAQ](/docs/faq.md)

--- a/docs/clean-promises.md
+++ b/docs/clean-promises.md
@@ -1,11 +1,11 @@
-###Clean Promise chaining and coordination
+### Clean Promise chaining and coordination
 
 There are many cases where you need to wait for multiple promises before doing something.
 Sometimes you need to run them in series, sometimes in parallel, sometimes you need all the results at the end,
 and sometimes you need each function to know about the results of the previous function.
 Following are some of the examples we could think of =D
 ***
-####Sequence (Waterfall)
+#### Sequence (Waterfall)
   output:
   ```
   1
@@ -14,7 +14,7 @@ Following are some of the examples we could think of =D
   //return a promise that resolves to 4
   ```
 
-#####Ugly Code:
+##### Ugly Code:
 ```javascript
 return foo(1).then(function foo(param1){
   console.info(param1);
@@ -27,7 +27,7 @@ return foo(1).then(function foo(param1){
       return promise.fufilled(4);
     });
 ```
-#####Clean Code:
+##### Clean Code:
 ```javascript
 function foo(param1) {
   console.info(param1);
@@ -54,7 +54,7 @@ return result;
 ```
 ***
 
-####Combination (Parallel)
+#### Combination (Parallel)
 ```javascript
 promise.all([foo, bar, baz]).then(function(values) {
   // prints 1,2,3 (in no particular order)

--- a/docs/har-dump.md
+++ b/docs/har-dump.md
@@ -1,6 +1,6 @@
 To capture the HTML Archive (HAR) file, add 'harFileName' attribute to options sent in with the test file.
 
-####Sample
+#### Sample
 ```javascript
 var fiveby = require('fiveby');
 

--- a/docs/pop.md
+++ b/docs/pop.md
@@ -1,6 +1,6 @@
-####How should I write tests?
+#### How should I write tests?
 
-#####1. Use the Page Object Pattern
+##### 1. Use the Page Object Pattern
 
   > Within your web app's UI there are areas that your tests interact with. A Page Object simply models these as objects within the test code. This reduces the amount of duplicated code and means that if the UI changes, the fix need only be applied in one place.
 
@@ -61,4 +61,4 @@
   > - Need not represent an entire page
 
 
-#####2. CSS should be your default *location strategy*. If CSS is not working in a specific case, you should make your html simpler and more semantic. Selectors that are not css will be highly scrutinized in reviews.
+##### 2. CSS should be your default *location strategy*. If CSS is not working in a specific case, you should make your html simpler and more semantic. Selectors that are not css will be highly scrutinized in reviews.

--- a/docs/properties.md
+++ b/docs/properties.md
@@ -1,4 +1,4 @@
-####Sample fiveby-config.json
+#### Sample fiveby-config.json
 ```json
 {
   "implicitWait": 5000,
@@ -17,7 +17,7 @@
   }
 }
 ```
-####Sample Usage
+#### Sample Usage
 ```javascript
 properties = propertyService.get('default'); //default is the namespace for properties set in fiveby-config.json
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
